### PR TITLE
Do not store explicit versions in the build properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -114,9 +114,6 @@
 
   <PropertyGroup>
     <OutputPath>$(StagingOutputRootPath)$(MSBuildProjectName)\</OutputPath>
-    <VCToolsVersion>14.15.26726</VCToolsVersion>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
-    <PlatformToolset>v141</PlatformToolset>
     <OutDir>$(OutputPath)</OutDir>
     <O>$(Platform)\$(Configuration)</O>
     <O Condition="'$(Platform)' == 'x86'">$(Configuration)</O>

--- a/README.md
+++ b/README.md
@@ -59,13 +59,11 @@ Earlier versions of MS-MPI are available from the [Microsoft Download Center](ht
     - Update _GFORTRAN_BIN_ in Derectory.Build.props to the install location of GFortran
  - [Perl](https://www.perl.org/get.html#win32)
 
- Based on the installed VS/SDK/WDK versions, update _VCToolsVersion_ and _WindowsTargetPlatformVersion_ in Directory.Build.props
-
 Note that the build system uses [CommonBuildToolSet(CBT)](https://commonbuildtoolset.github.io/). You may need to unblock __CBT.core.dll__ (under .build/CBT) depending on your security configurations. Please refer to [CBT documentation](https://commonbuildtoolset.github.io/#/getting-started) for additional details.
 
 
 ## Build
-To build, open a __Native Tools Command Prompt for Visual Studio__ and  run ``msbuild`` from root folder.
+To build, open a __Native Tools Command Prompt for Visual Studio__ and  run ``msbuild /p:WindowsTargetPlatformVersion=<WindowsTargetPlatformVersion> /p:PlatformToolset=<PlatformToolset>`` from root folder, where `<WindowsTargetPlatformVersion>` and `<PlatformToolset>` should be selected based on your installed VS/SDK/WDK versions.
 
 # Contributing
 


### PR DESCRIPTION
Instead they can be passed as command line arguments to `msbuild`. The README is adjusted accordingly.